### PR TITLE
feat: GA tracking id를 환경변수에서 가져오지 않게함

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,1 +1,0 @@
-GA_TRACKING_ID=

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -17,12 +17,12 @@ export default class MyDocument extends Document {
           />
         </Head>
         {/* Global site tag (gtag.js) - Google Analytics */}
-        {process.env.NODE_ENV === 'production' && <script async src={`https://www.googletagmanager.com/gtag/js?id=${process.env.GA_TRACKING_ID}`}></script>}
+        {process.env.NODE_ENV === 'production' && <script async src={`https://www.googletagmanager.com/gtag/js?id=GA_TRACKING_ID=G-4NVCH63T47`}></script>}
         {process.env.NODE_ENV === 'production' && <script dangerouslySetInnerHTML={{ __html: `window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
 
-          gtag('config', '${process.env.GA_TRACKING_ID}');`}} />}
+          gtag('config', 'GA_TRACKING_ID=G-4NVCH63T47');`}} />}
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
어차피 페이지 html에서 tracking id가 노출되기 때문에 숨길 필요가 없음